### PR TITLE
chore: migrate eligible workflows to ubuntu-slim runner

### DIFF
--- a/.github/workflows/_create-scrap.yml
+++ b/.github/workflows/_create-scrap.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   create-scrap:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       output: ${{ steps.create.outputs.scrap }}
     steps:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -49,7 +49,7 @@ jobs:
     # build が skipped だと needs 経由で deploy も skipped になるのがデフォルト挙動だが、
     # 明示的に success を要求することで将来 `if: always()` 等の誤変更時のリグレッションを防ぐ
     if: ${{ needs.build.result == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/recent-contributions.yml
+++ b/.github/workflows/recent-contributions.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary
Ubuntu Slim Runner は軽量・低コストなランナーで、以下のような軽量ワークフロー向きです:
- release-please / PR タイトル検証 / claude-code / tag 自動化 / 軽量 Node CI 等

制約 (15分タイムアウト / unprivileged container / 最小プリインツール) に合致するワークフローのみ対象としています。Gradle/Rust/Go/Dart/fastlane 等の重量ビルドは対象外です。

### 変更対象
- `.github/workflows/_create-scrap.yml`
- `.github/workflows/gh-pages.yml` (deploy ジョブのみ、build ジョブは変更しない)
- `.github/workflows/recent-contributions.yml`

### 調査の詳細
関連調査タスク: yshrsmz 配下リポジトリの Slim Runner 化可能性調査 (2026-04-15 完了)

## Test plan
- [ ] PR 作成後、対象ワークフローが push/label/issue 等のトリガーで正常に動作することを確認