### PR TITLE
chore(renovate): migrate to yshrsmz/renovate-config presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,20 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "reviewers": ["yshrsmz"],
   "extends": [
-    "config:best-practices",
-    ":pinDependencies",
-    ":pinDevDependencies"
+    "github>yshrsmz/renovate-config",
+    "github>yshrsmz/renovate-config:github-actions",
+    "github>yshrsmz/renovate-config:npm"
   ],
-  "lockFileMaintenance": {
-    "enabled": true
-  },
   "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "matchPackageNames": ["*"]
-    },
     {
       "matchManagers": ["github-actions"],
       "matchDepNames": ["yshrsmz/yshrsmz.github.io"],


### PR DESCRIPTION
## Summary

`yshrsmz/renovate-config` の共有プリセットを参照する形に `renovate.json` を移行する。

### 置換内容

| Before | After |
|---|---|
| `config:best-practices` | `github>yshrsmz/renovate-config` (default に内包) |
| `:pinDependencies` / `:pinDevDependencies` | `github>yshrsmz/renovate-config:npm` に内包 |
| `lockFileMaintenance: { enabled: true }` | default の `:maintainLockFilesWeekly` で代替 |
| `packageRules` の "all non-major dependencies" | preset の manager 別グループ化 (`npm dependencies` / `GitHub Actions`) で代替 |

### 保持した項目

- `reviewers: ["yshrsmz"]`
- `packageRules` の自リポ GitHub Actions スキップ (`yshrsmz/yshrsmz.github.io`)

### 挙動の変化

- `minimumReleaseAge: "2 weeks"` が default preset から適用される（新規 PR が 2 週間遅延）
- schedule が `* 9-12 * * 1` (月曜 9-12 時, Asia/Tokyo) に固定される
- `prHourlyLimit: 5`, `internalChecksFilter: strict` が適用される
- minor/patch 更新が npm と github-actions で別 PR に分離される（旧来は全マネージャー横断の単一 PR）
- semantic commits / dependency dashboard が有効化される
- vulnerability アラートは preset により即時対応 (`minimumReleaseAge: "0 days"`) に切り替わる

### 関連

- 別ローカルブランチ `chore/add-renovate-reviewer` の `reviewers` 追加コミット (65f0dc27) は既に development に取り込み済みのため、本 PR にも反映済み。ローカルブランチは削除して問題なし。

## Test plan

- [x] `pnpm dlx --package=renovate@40.16.0 renovate-config-validator renovate.json` で validate 通過
- [ ] Renovate Cloud の次回スキャンで Dependency Dashboard / 新 PR が想定通り生成されるか確認